### PR TITLE
Revise chocolateyinstall.ps1 to not use Start-ChocolateyProcessAsAdmin

### DIFF
--- a/installers/1.6.2/chocolatey/apache-spark/tools/chocolateyinstall.ps1
+++ b/installers/1.6.2/chocolatey/apache-spark/tools/chocolateyinstall.ps1
@@ -2,6 +2,7 @@
 
 $packageName= 'apache-spark' # arbitrary name for the package, used in messages
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$fileLocation = Join-Path $toolsDir 'install-spark1.6.2.ps1'
+$psFile = Join-Path $toolsDir 'install-spark1.6.2.ps1'
 
-Start-ChocolateyProcessAsAdmin "& `'$fileLocation`'"
+Install-ChocolateyPowershellCommand -PackageName 'install-spark1.6.2.powershell' -PSFileFullPath $psFile
+Invoke-Expression -Command 'install-spark1.6.2'


### PR DESCRIPTION
This is to resolve issue with verification on the Chocolatey CI verification, as well as resolves issue with stderr outputting what should be stdout when executing the installation script.  Will push to Chocolatey if all good.